### PR TITLE
Projects backend testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,31 @@
 
     <dependency>
       <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.64</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
-
+    
     <!-- https://mvnrepository.com/artifact/org.kohsuke/github-api -->
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
@@ -2,6 +2,7 @@ package com.google.opensesame.projects;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -134,5 +135,27 @@ public class ProjectEntityTest {
         new ProjectEntity[] { firstMockProject, secondMockProject, thirdMockProject };
     assertNotNull(queryResult);
     assertArrayEquals(expectedQueryResult, queryResult.toArray());
+  }
+
+  @Test
+  public void fromRepositoryId() {
+    // Expect the function to return an existing ProjectEntity from the Datastore because an entity
+    // with the supplied ID already exists.
+
+    ProjectEntity projectEntity = 
+        ProjectEntity.fromRepositoryIdOrNew(firstMockProject.repositoryId);
+
+    assertEquals(firstMockProject, projectEntity);
+  }
+
+  @Test
+  public void fromNewRepositoryId() {
+    // Expect the function to return a new ProjectEntity because no entity with that supplied ID
+    // exists in the Datastore.
+
+    String newId = "newId";
+    ProjectEntity projectEntity = ProjectEntity.fromRepositoryIdOrNew(newId);
+
+    assertEquals(newId, projectEntity.repositoryId);
   }
 }

--- a/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
@@ -1,0 +1,138 @@
+package com.google.opensesame.projects;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.googlecode.objectify.ObjectifyFactory;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.util.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.Test;
+
+@RunWith(JUnit4.class)
+public class ProjectEntityTest {
+  private final LocalServiceTestHelper helper = 
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+  private Closeable session;
+
+  private ProjectEntity firstMockProject;
+  private ProjectEntity secondMockProject;
+  private ProjectEntity thirdMockProject;
+  
+  private HttpServletResponse mockResponse;
+  private StringWriter responseStringWriter;
+
+  @BeforeClass
+  public static void objectifyClassSetup() {
+    ObjectifyService.setFactory(new ObjectifyFactory());
+    ObjectifyService.register(ProjectEntity.class);
+  }
+
+  @Before
+  public void objectifySetUp() throws IOException {
+    session = ObjectifyService.begin();
+    helper.setUp();
+  }
+
+  @Before
+  public void mockProjectSetUp() {
+    firstMockProject = new ProjectEntity(
+        "273537467", Arrays.asList("Mentor 1", "Mentor 2", "Mentor 3"), Arrays.asList());
+    secondMockProject = 
+        new ProjectEntity("45717250", Arrays.asList("Mentor 1", "Mentor 2"), Arrays.asList());
+    thirdMockProject = 
+        new ProjectEntity("20580498", Arrays.asList("Mentor 1"), Arrays.asList());
+    ofy().save().entities(firstMockProject, secondMockProject, thirdMockProject).now();
+  }
+
+  @Before
+  public void mockResponseSetUp() throws IOException {
+    mockResponse = mock(HttpServletResponse.class);
+    responseStringWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseStringWriter));
+  }
+
+  @After
+  public void objectifyTearDown() {
+    session.close();
+    helper.tearDown();
+  }
+  
+  @Test
+  public void queryByIds() throws IOException {
+    // Expect to receive the ProjectEntities with the corresponding repository IDs.
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameterValues(ProjectEntity.PROJECT_ID_PARAM))
+        .thenReturn(new String[] { firstMockProject.repositoryId, secondMockProject.repositoryId });
+
+    Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
+    Collection<ProjectEntity> expected = Arrays.asList(firstMockProject, secondMockProject);
+    assertNotNull(queryResult);
+    assertTrue(queryResult.size() == expected.size() && queryResult.containsAll(expected));
+    verify(mockResponse, never()).setStatus(anyInt());
+  }
+
+  @Test
+  public void queryNoIds() throws IOException {
+    // Expect to receive no ProjectEntities because the list of IDs was defined but empty.
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameterValues(ProjectEntity.PROJECT_ID_PARAM)).thenReturn(new String[] {});
+
+    Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
+    assertNotNull(queryResult);
+    assertTrue(queryResult.size() == 0);
+    verify(mockResponse, never()).setStatus(anyInt());
+  }
+
+  @Test
+  public void queryWithInvalidId() throws IOException {
+    // Expect to receive an error response of 404 (resource not found) because one or more IDs
+    // could not be found within the Datastore.
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameterValues(ProjectEntity.PROJECT_ID_PARAM))
+        .thenReturn(new String[] { firstMockProject.repositoryId, "invalidID" });
+
+    Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
+    assertNull(queryResult);
+    verify(mockResponse, times(1)).setStatus(HttpServletResponse.SC_NOT_FOUND);
+  }
+
+  @Test
+  public void queryWithoutIds() throws IOException {
+    // Expect to receive all ProjectEntities in order of descending number of mentors because no
+    // list of IDs was supplied.
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
+    ProjectEntity[] expectedQueryResult = 
+        new ProjectEntity[] { firstMockProject, secondMockProject, thirdMockProject };
+    assertNotNull(queryResult);
+    assertArrayEquals(expectedQueryResult, queryResult.toArray());
+  }
+}

--- a/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
@@ -91,6 +91,7 @@ public class ProjectEntityTest {
 
     Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
     Collection<ProjectEntity> expected = Arrays.asList(firstMockProject, secondMockProject);
+
     assertNotNull(queryResult);
     assertTrue(queryResult.size() == expected.size() && queryResult.containsAll(expected));
     verify(mockResponse, never()).setStatus(anyInt());

--- a/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
@@ -82,7 +82,7 @@ public class ProjectEntityTest {
   }
 
   @Test
-  public void queryByIds() throws IOException {
+  public void queryByIdsShouldReturnProjectsWithThoseIds() throws IOException {
     // Expect to receive the ProjectEntities with the corresponding repository IDs.
 
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -98,7 +98,7 @@ public class ProjectEntityTest {
   }
 
   @Test
-  public void queryNoIds() throws IOException {
+  public void queryWithNoIdsShouldReturnEmpty() throws IOException {
     // Expect to receive no ProjectEntities because the list of IDs was defined but empty.
 
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -111,7 +111,7 @@ public class ProjectEntityTest {
   }
 
   @Test
-  public void queryWithInvalidId() throws IOException {
+  public void queryWithInvalidIdShouldRaiseError() throws IOException {
     // Expect to receive an error response of 404 (resource not found) because one or more IDs
     // could not be found within the Datastore.
 
@@ -125,7 +125,7 @@ public class ProjectEntityTest {
   }
 
   @Test
-  public void queryWithoutIds() throws IOException {
+  public void queryWithoutIdsShouldReturnAllProjects() throws IOException {
     // Expect to receive all ProjectEntities in order of descending number of mentors because no
     // list of IDs was supplied.
 
@@ -139,7 +139,7 @@ public class ProjectEntityTest {
   }
 
   @Test
-  public void fromRepositoryId() {
+  public void fromExistingRepositoryIdShouldReturnExistingProject() {
     // Expect the function to return an existing ProjectEntity from the Datastore because an entity
     // with the supplied ID already exists.
 
@@ -150,7 +150,7 @@ public class ProjectEntityTest {
   }
 
   @Test
-  public void fromNewRepositoryId() {
+  public void fromNewRepositoryIdShouldReturnNewProject() {
     // Expect the function to return a new ProjectEntity because no entity with that supplied ID
     // exists in the Datastore.
 

--- a/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
@@ -52,7 +52,7 @@ public class ProjectEntityTest {
   }
 
   @Before
-  public void objectifySetUp() throws IOException {
+  public void objectifyStartSession() throws IOException {
     session = ObjectifyService.begin();
     helper.setUp();
   }
@@ -76,7 +76,7 @@ public class ProjectEntityTest {
   }
 
   @After
-  public void objectifyTearDown() {
+  public void objectifyEndSession() {
     session.close();
     helper.tearDown();
   }

--- a/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectEntityTest.java
@@ -28,20 +28,20 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class ProjectEntityTest {
-  private final LocalServiceTestHelper helper = 
+  private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
   private Closeable session;
 
   private ProjectEntity firstMockProject;
   private ProjectEntity secondMockProject;
   private ProjectEntity thirdMockProject;
-  
+
   private HttpServletResponse mockResponse;
   private StringWriter responseStringWriter;
 
@@ -59,12 +59,12 @@ public class ProjectEntityTest {
 
   @Before
   public void mockProjectSetUp() {
-    firstMockProject = new ProjectEntity(
-        "273537467", Arrays.asList("Mentor 1", "Mentor 2", "Mentor 3"), Arrays.asList());
-    secondMockProject = 
+    firstMockProject =
+        new ProjectEntity(
+            "273537467", Arrays.asList("Mentor 1", "Mentor 2", "Mentor 3"), Arrays.asList());
+    secondMockProject =
         new ProjectEntity("45717250", Arrays.asList("Mentor 1", "Mentor 2"), Arrays.asList());
-    thirdMockProject = 
-        new ProjectEntity("20580498", Arrays.asList("Mentor 1"), Arrays.asList());
+    thirdMockProject = new ProjectEntity("20580498", Arrays.asList("Mentor 1"), Arrays.asList());
     ofy().save().entities(firstMockProject, secondMockProject, thirdMockProject).now();
   }
 
@@ -80,14 +80,14 @@ public class ProjectEntityTest {
     session.close();
     helper.tearDown();
   }
-  
+
   @Test
   public void queryByIds() throws IOException {
     // Expect to receive the ProjectEntities with the corresponding repository IDs.
 
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getParameterValues(ProjectEntity.PROJECT_ID_PARAM))
-        .thenReturn(new String[] { firstMockProject.repositoryId, secondMockProject.repositoryId });
+        .thenReturn(new String[] {firstMockProject.repositoryId, secondMockProject.repositoryId});
 
     Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
     Collection<ProjectEntity> expected = Arrays.asList(firstMockProject, secondMockProject);
@@ -116,7 +116,7 @@ public class ProjectEntityTest {
 
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getParameterValues(ProjectEntity.PROJECT_ID_PARAM))
-        .thenReturn(new String[] { firstMockProject.repositoryId, "invalidID" });
+        .thenReturn(new String[] {firstMockProject.repositoryId, "invalidID"});
 
     Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
     assertNull(queryResult);
@@ -131,8 +131,8 @@ public class ProjectEntityTest {
     HttpServletRequest request = mock(HttpServletRequest.class);
 
     Collection<ProjectEntity> queryResult = ProjectEntity.queryFromRequest(request, mockResponse);
-    ProjectEntity[] expectedQueryResult = 
-        new ProjectEntity[] { firstMockProject, secondMockProject, thirdMockProject };
+    ProjectEntity[] expectedQueryResult =
+        new ProjectEntity[] {firstMockProject, secondMockProject, thirdMockProject};
     assertNotNull(queryResult);
     assertArrayEquals(expectedQueryResult, queryResult.toArray());
   }
@@ -142,7 +142,7 @@ public class ProjectEntityTest {
     // Expect the function to return an existing ProjectEntity from the Datastore because an entity
     // with the supplied ID already exists.
 
-    ProjectEntity projectEntity = 
+    ProjectEntity projectEntity =
         ProjectEntity.fromRepositoryIdOrNew(firstMockProject.repositoryId);
 
     assertEquals(firstMockProject, projectEntity);


### PR DESCRIPTION
Add testing for querying the projects Datastore.

* Add the necessary dependencies for creating in-memory test instances of Datastore and Objectify.
* Add tests for `ProjectEntity.queryFromRequest` which is used by all of the project data servlets.
* Add tests for the `ProjectEntity.fromRepositoryIdOrNew` which is used by the Mentor's `doPost` servlet.