### PR TITLE
Add repo GitHub link to the project breakout page 

### DIFF
--- a/src/main/java/com/google/opensesame/projects/ProjectData.java
+++ b/src/main/java/com/google/opensesame/projects/ProjectData.java
@@ -26,7 +26,7 @@ public class ProjectData {
   private Integer numMentors = null;
   private String repositoryId = null;
   private List<UserData> mentors = null;
-  private String gitHubHtmlUrl = null;
+  private String gitHubUrl = null;
 
   /**
    * Create a ProjectData object from a ProjectEntity and its associated GitHub repository.
@@ -165,11 +165,11 @@ public class ProjectData {
    *
    * @return Returns the URL of the GitHub page.
    */
-  public String getGitHubHtmlUrl() {
-    if (gitHubHtmlUrl == null) {
-      gitHubHtmlUrl = repository.getHtmlUrl().toString();
+  public String getGitHubUrl() {
+    if (gitHubUrl == null) {
+      gitHubUrl = repository.getHtmlUrl().toString();
     }
 
-    return gitHubHtmlUrl;
+    return gitHubUrl;
   }
 }

--- a/src/main/java/com/google/opensesame/projects/ProjectData.java
+++ b/src/main/java/com/google/opensesame/projects/ProjectData.java
@@ -162,7 +162,7 @@ public class ProjectData {
 
   /**
    * Gets the URL of the GitHub page for the repository.
-   * 
+   *
    * @return Returns the URL of the GitHub page.
    */
   public String getGitHubHtmlUrl() {

--- a/src/main/java/com/google/opensesame/projects/ProjectData.java
+++ b/src/main/java/com/google/opensesame/projects/ProjectData.java
@@ -26,6 +26,7 @@ public class ProjectData {
   private Integer numMentors = null;
   private String repositoryId = null;
   private List<UserData> mentors = null;
+  private String gitHubHtmlUrl = null;
 
   /**
    * Create a ProjectData object from a ProjectEntity and its associated GitHub repository.
@@ -157,5 +158,18 @@ public class ProjectData {
     }
 
     return Collections.unmodifiableList(mentors);
+  }
+
+  /**
+   * Gets the URL of the GitHub page for the repository.
+   * 
+   * @return Returns the URL of the GitHub page.
+   */
+  public String getGitHubHtmlUrl() {
+    if (gitHubHtmlUrl == null) {
+      gitHubHtmlUrl = repository.getHtmlUrl().toString();
+    }
+
+    return gitHubHtmlUrl;
   }
 }

--- a/src/main/java/com/google/opensesame/servlets/ProjectFullServlet.java
+++ b/src/main/java/com/google/opensesame/servlets/ProjectFullServlet.java
@@ -31,7 +31,7 @@ public class ProjectFullServlet extends HttpServlet {
     projectData.getNumMentors();
     projectData.getRepositoryId();
     projectData.getMentors();
-    projectData.getGitHubHtmlUrl();
+    projectData.getGitHubUrl();
 
     return projectData;
   }

--- a/src/main/java/com/google/opensesame/servlets/ProjectFullServlet.java
+++ b/src/main/java/com/google/opensesame/servlets/ProjectFullServlet.java
@@ -31,6 +31,7 @@ public class ProjectFullServlet extends HttpServlet {
     projectData.getNumMentors();
     projectData.getRepositoryId();
     projectData.getMentors();
+    projectData.getGitHubHtmlUrl();
 
     return projectData;
   }

--- a/src/main/webapp/js/projects/react/components/ExpandedProject.js
+++ b/src/main/webapp/js/projects/react/components/ExpandedProject.js
@@ -44,7 +44,7 @@ export function ExpandedProject(props) {
               <div className={'d-flex mr-4 justify-content-center' +
                   ' align-items-center'}>
                 <a
-                  href={project.gitHubHtmlUrl}
+                  href={project.gitHubUrl}
                   className="emphasis"
                   title={PROJECT_GITHUB_ICON_TITLE}>
                   <i className="fab fa-3x fa-github-square"></i>

--- a/src/main/webapp/js/projects/react/components/ExpandedProject.js
+++ b/src/main/webapp/js/projects/react/components/ExpandedProject.js
@@ -33,20 +33,20 @@ export function ExpandedProject(props) {
       <div className="row mt-4">
         <div className="col-md-9">
           <div className="card mx-1 mb-2">
-            <div className={"card-body px-3 py-2 d-inline-flex"
-                + " justify-content-between"}>
+            <div className={'card-body px-3 py-2 d-inline-flex' +
+                ' justify-content-between'}>
               <div>
                 <h1 className="card-title emphasis">
                   {project.name}
                 </h1>
                 <TagList tags={projectTags} />
               </div>
-              <div className={"d-flex mr-4 justify-content-center"
-                  + " align-items-center"}>
-                <a 
-                    href={project.gitHubHtmlUrl}
-                    className="emphasis"
-                    title={PROJECT_GITHUB_ICON_TITLE}>
+              <div className={'d-flex mr-4 justify-content-center' +
+                  ' align-items-center'}>
+                <a
+                  href={project.gitHubHtmlUrl}
+                  className="emphasis"
+                  title={PROJECT_GITHUB_ICON_TITLE}>
                   <i className="fab fa-3x fa-github-square"></i>
                 </a>
               </div>

--- a/src/main/webapp/js/projects/react/components/ExpandedProject.js
+++ b/src/main/webapp/js/projects/react/components/ExpandedProject.js
@@ -2,6 +2,8 @@ import {TagList} from './TagList.js';
 import {MentorCard} from './MentorCard.js';
 import {expandedProjectType} from '../prop_types.js';
 
+export const PROJECT_GITHUB_ICON_TITLE = 'View This Project on GitHub';
+
 /**
  * An expanded view of a project.
  * @param {Object} props
@@ -31,11 +33,23 @@ export function ExpandedProject(props) {
       <div className="row mt-4">
         <div className="col-md-9">
           <div className="card mx-1 mb-2">
-            <div className="card-body px-3 py-2">
-              <h1 className="card-title emphasis">
-                {project.name}
-              </h1>
-              <TagList tags={projectTags} />
+            <div className={"card-body px-3 py-2 d-inline-flex"
+                + " justify-content-between"}>
+              <div>
+                <h1 className="card-title emphasis">
+                  {project.name}
+                </h1>
+                <TagList tags={projectTags} />
+              </div>
+              <div className={"d-flex mr-4 justify-content-center"
+                  + " align-items-center"}>
+                <a 
+                    href={project.gitHubHtmlUrl}
+                    className="emphasis"
+                    title={PROJECT_GITHUB_ICON_TITLE}>
+                  <i className="fab fa-3x fa-github-square"></i>
+                </a>
+              </div>
             </div>
           </div>
           <div className="ml-1 emphasis">Mentors:</div>

--- a/src/main/webapp/js/projects/react/prop_types.js
+++ b/src/main/webapp/js/projects/react/prop_types.js
@@ -26,4 +26,5 @@ export const mentorType = PropTypes.shape({
 export const expandedProjectType = PropTypes.shape({
   ...projectPreviewData,
   mentors: PropTypes.arrayOf(mentorType).isRequired,
+  gitHubHtmlUrl: PropTypes.string.isRequired,
 });

--- a/src/main/webapp/js/projects/react/prop_types.js
+++ b/src/main/webapp/js/projects/react/prop_types.js
@@ -26,5 +26,5 @@ export const mentorType = PropTypes.shape({
 export const expandedProjectType = PropTypes.shape({
   ...projectPreviewData,
   mentors: PropTypes.arrayOf(mentorType).isRequired,
-  gitHubHtmlUrl: PropTypes.string.isRequired,
+  gitHubUrl: PropTypes.string.isRequired,
 });

--- a/src/main/webapp/js/tests/ExpandedProject.test.js
+++ b/src/main/webapp/js/tests/ExpandedProject.test.js
@@ -29,7 +29,7 @@ const mockProject = {
       name: 'Sami Alves',
     },
   ],
-  gitHubHtmlUrl: 'https://github.com/googleinterns/open-sesame',
+  gitHubUrl: 'https://github.com/googleinterns/open-sesame',
 };
 
 describe('Project breakout page', () => {
@@ -51,7 +51,7 @@ describe('Project breakout page', () => {
     render(<ExpandedProject loading={false} project={mockProject} />);
 
     expect(screen.getByTitle(PROJECT_GITHUB_ICON_TITLE))
-        .toHaveAttribute('href', mockProject.gitHubHtmlUrl);
+        .toHaveAttribute('href', mockProject.gitHubUrl);
   });
 
   it('renders the mentor cards', () => {

--- a/src/main/webapp/js/tests/ExpandedProject.test.js
+++ b/src/main/webapp/js/tests/ExpandedProject.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ExpandedProject} from '../projects/react/components/ExpandedProject.js';
+import {ExpandedProject, PROJECT_GITHUB_ICON_TITLE} from '../projects/react/components/ExpandedProject.js'; // eslint-disable-line
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen, getByText} from '@testing-library/react';
 
@@ -29,6 +29,7 @@ const mockProject = {
       name: 'Sami Alves',
     },
   ],
+  gitHubHtmlUrl: 'https://github.com/googleinterns/open-sesame',
 };
 
 describe('Project breakout page', () => {
@@ -44,6 +45,13 @@ describe('Project breakout page', () => {
     const elem = render(<ExpandedProject loading={true} />);
 
     expect(elem.container.firstChild).not.toBeNull();
+  });
+
+  it('provides a link to the repository GitHub page', () => {
+    render(<ExpandedProject loading={false} project={mockProject} />);
+
+    expect(screen.getByTitle(PROJECT_GITHUB_ICON_TITLE))
+        .toHaveAttribute('href', mockProject.gitHubHtmlUrl);
   });
 
   it('renders the mentor cards', () => {

--- a/src/main/webapp/projects.html
+++ b/src/main/webapp/projects.html
@@ -22,6 +22,8 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    <!-- FontAwesome Scripts -->
+    <script src="https://kit.fontawesome.com/64201e6bf1.js" crossorigin="anonymous"></script>
     
     <!-- Load React. -->
     <!-- Note: when deploying, replace "development.js" with "production.min.js". -->


### PR DESCRIPTION
Add a repo GitHub link to the project breakout page.

* Add support for getting the HTML URL on the backend.
* Add the repo link to a clickable [FontAwesome GitHub icon](https://fontawesome.com/icons/github-square?style=brands) in the project title card.
* Add testing for the presence of a GitHub HTML URL on the project breakout page.