### PR TITLE
Sort mentors.

### DIFF
--- a/src/main/java/com/google/opensesame/servlets/MentorsServlet.java
+++ b/src/main/java/com/google/opensesame/servlets/MentorsServlet.java
@@ -37,24 +37,26 @@ public class MentorsServlet extends HttpServlet {
       mentors.add(new UserData(mentorEntity));
     }
 
-    //If the user is logged in and has a profile, sort mentors by common interest.
+    // If the user is logged in and has a profile, sort mentors by common interest.
     User loggedInUser = AuthServlet.getAuthorizedUser();
     if (loggedInUser != null) {
       String userID = loggedInUser.getUserId();
       UserEntity curUser = ofy().load().type(UserEntity.class).id(userID).now();
       if (curUser != null) {
         final UserData curUserData = new UserData(curUser);
-        Collections.sort(mentors, new Comparator<UserData>() {
-          @Override
-          public int compare(UserData u1, UserData u2) {
-            Integer u1Compatibility = new Integer(u1.compatibility(curUserData));
-            Integer u2Compatibility = new Integer(u2.compatibility(curUserData));
-            return u2Compatibility.compareTo(u1Compatibility);
-          }
-        });
+        Collections.sort(
+            mentors,
+            new Comparator<UserData>() {
+              @Override
+              public int compare(UserData u1, UserData u2) {
+                Integer u1Compatibility = new Integer(u1.compatibility(curUserData));
+                Integer u2Compatibility = new Integer(u2.compatibility(curUserData));
+                return u2Compatibility.compareTo(u1Compatibility);
+              }
+            });
       }
     }
-    
+
     String jsonMentors = new Gson().toJson(mentors);
     response.setContentType("application/json;");
     response.getWriter().println(jsonMentors);

--- a/src/main/java/com/google/opensesame/servlets/MentorsServlet.java
+++ b/src/main/java/com/google/opensesame/servlets/MentorsServlet.java
@@ -2,6 +2,7 @@ package com.google.opensesame.servlets;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
+import com.google.appengine.api.users.User;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.opensesame.auth.AuthServlet;
@@ -11,6 +12,8 @@ import com.google.opensesame.user.UserData;
 import com.google.opensesame.user.UserEntity;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -26,14 +29,32 @@ public class MentorsServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
-    addMockMentor(response); // TODO: remove by production
     List<UserEntity> mentorEntities =
         ofy().load().type(UserEntity.class).filter("isMentor", true).list();
+    System.out.println(mentorEntities);
     ArrayList<UserData> mentors = new ArrayList<UserData>();
     for (UserEntity mentorEntity : mentorEntities) {
       mentors.add(new UserData(mentorEntity));
     }
 
+    //If the user is logged in and has a profile, sort mentors by common interest.
+    User loggedInUser = AuthServlet.getAuthorizedUser();
+    if (loggedInUser != null) {
+      String userID = loggedInUser.getUserId();
+      UserEntity curUser = ofy().load().type(UserEntity.class).id(userID).now();
+      if (curUser != null) {
+        final UserData curUserData = new UserData(curUser);
+        Collections.sort(mentors, new Comparator<UserData>() {
+          @Override
+          public int compare(UserData u1, UserData u2) {
+            Integer u1Compatibility = new Integer(u1.compatibility(curUserData));
+            Integer u2Compatibility = new Integer(u2.compatibility(curUserData));
+            return u2Compatibility.compareTo(u1Compatibility);
+          }
+        });
+      }
+    }
+    
     String jsonMentors = new Gson().toJson(mentors);
     response.setContentType("application/json;");
     response.getWriter().println(jsonMentors);

--- a/src/main/java/com/google/opensesame/user/UserData.java
+++ b/src/main/java/com/google/opensesame/user/UserData.java
@@ -140,10 +140,11 @@ public class UserData {
     }
   }
 
-  /** @param {UserData} user2 the user to compare to
-    * @return an integer 'compatibility score' which represents
-    * how many shared interests two users have. 
-    */
+  /**
+   * @param {UserData} user2 the user to compare to
+   * @return an integer 'compatibility score' which represents how many shared interests two users
+   *     have.
+   */
   public int compatibility(UserData user2) {
     ArrayList<String> user1Interests = (ArrayList) this.interestTags.clone();
     ArrayList<String> user2Interests = (ArrayList) user2.interestTags.clone();

--- a/src/main/java/com/google/opensesame/user/UserData.java
+++ b/src/main/java/com/google/opensesame/user/UserData.java
@@ -139,4 +139,16 @@ public class UserData {
       projects.add(curProject);
     }
   }
+
+  /** @param {UserData} user2 the user to compare to
+    * @return an integer 'compatibility score' which represents
+    * how many shared interests two users have. 
+    */
+  public int compatibility(UserData user2) {
+    ArrayList<String> user1Interests = (ArrayList) this.interestTags.clone();
+    ArrayList<String> user2Interests = (ArrayList) user2.interestTags.clone();
+    user1Interests.retainAll(user2Interests);
+    System.out.println(user1Interests.size());
+    return user1Interests.size();
+  }
 }


### PR DESCRIPTION
When the user is logged in and has a profile, sort the mentors on the mentor search page by # of shared interests.

- Add a 'compatibility' function to the UserData class. Currently this function just returns the number of shared interest tags between two users.
- Add to the doGet function of the MentorsServlet. Now, before returning the list of mentors, first check if the user is authenticated and has a profile in datastore. If so, sort the mentor list based on the UserData 'compatibility' function.